### PR TITLE
Change default eslintrc filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-_Nothing yet..._
+### Changed
+- Change default eslintrc filename to `.eslintrc.json` (instead of `.eslintrc`).
 
 ## 0.3.0 - 2018-08-28 Updated dependencies
 

--- a/main.js
+++ b/main.js
@@ -94,7 +94,7 @@ try {
     execSync(
       `cp ${path.join(__dirname, 'eslintrc.template')} ${path.join(
         cwd,
-        '.eslintrc',
+        '.eslintrc.json',
       )}`,
     );
     console.log('We created `.eslintrc.json` for you.');


### PR DESCRIPTION
Currently the default eslint config file is created as `.eslintrc`. This name is deprecated (see https://eslint.org/docs/user-guide/configuring#configuration-file-formats), so given the format used is JSON the right name should be `.eslintrc.json` (as mentioned in the message printed after generating it, in fact 😅) 