### PR TITLE
[backpack-love] Add changelog link to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This package contains an encapsulated setup for ESLint according to Skyscannner's best practices plus integrated support for Prettier via eslint fix.
 
 ## Changelog
- The up-to-date changelog can be found [here](./CHANGELOG.md)
+[View our up-to-date changelog](./CHANGELOG.md)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 This package contains an encapsulated setup for ESLint according to Skyscannner's best practices plus integrated support for Prettier via eslint fix.
 
+## Changelog
+ The up-to-date changelog can be found [here](./CHANGELOG.md)
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
The main readme is the place where to look for things, using backpack from the other side I notice how annoying is not to have that link in the readme