### PR TITLE
Add "import/order" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,13 @@ module.exports = {
   extends: ['skyscanner', 'prettier', 'prettier/react'],
   plugins: ['prettier'],
   rules: {
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
+        'newlines-between': 'always',
+      },
+    ],
     'prettier/prettier': 'error',
   },
 };

--- a/main.js
+++ b/main.js
@@ -20,6 +20,7 @@
 /* eslint-disable no-console */
 const path = require('path');
 const fs = require('fs');
+
 const colors = require('colors/safe');
 
 if (


### PR DESCRIPTION
Hi,

Given that Prettier is quite opinionated on the code formatting, I think it makes sense to make this config a bit more strict on the order of the imports and the new lines between them.

In my opinion, this helps a bit when reading the code, and also standardising a bit more the imports.

What do you think about this?