### PR TITLE
[NOJIRA] Upgrade to eslint-config-skyscanner@beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+
+- Depend on the beta version of `eslint-config-skyscanner`.
+
 ## 0.7.0 - 2019-01-30
 
 - Bump `eslint-config-skyscanner` to `4.0.0`.

--- a/main.js
+++ b/main.js
@@ -20,6 +20,7 @@
 /* eslint-disable no-console */
 const path = require('path');
 const fs = require('fs');
+
 const colors = require('colors/safe');
 
 if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -491,9 +491,9 @@
       }
     },
     "eslint-config-skyscanner": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-skyscanner/-/eslint-config-skyscanner-4.0.0.tgz",
-      "integrity": "sha512-yLGLd4LeL4wCjEmIbq9FGUp7WeZWljjO3UvrpDNfwUYfdEi2KTbKbqqRpiiFo0zQrSTTOndqtNutlXmUUTKebQ=="
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-skyscanner/-/eslint-config-skyscanner-5.0.0-beta.1.tgz",
+      "integrity": "sha512-oZsK0Cbb5H7qHgT9Zhin29FKXSDqsz1kV4jWHt6l3qNoU2hsYQnpMshc/HU9vXmwbUjkjczDSdIE4GAtu7Co9w=="
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint": "^5.12.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^3.3.0",
-    "eslint-config-skyscanner": "4.0.0",
+    "eslint-config-skyscanner": "5.0.0-beta.1",
     "eslint-plugin-backpack": "^0.2.2",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",


### PR DESCRIPTION
We have 2 version bump options:
1. `0.8.0`
2. `0.8.0-beta.1`

I vote for option 2 as this package is pre 1.0 anyways