### PR TITLE
Update node engine to Erbium

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,11 +43,11 @@ limitations under the License.
 eslint-config-skyscanner-with-prettier is developed using Node, using the following versions:
 
 * `LTS` (Node)
-* `^5.6.0` (npm)
+* `^6.4.1` (npm)
 
 If you use [nvm](https://github.com/creationix/nvm) or [nave](https://github.com/isaacs/nave) to manage your Node environment, eslint-config-skyscanner-with-prettier has built-in support for these. Just run `nvm use` or `nave auto` to install the correct Node version.
 
-To install npm, use `npm install --global npm@^5.6.0`.
+To install npm, use `npm install --global npm@^6.4.1`.
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-skyscanner-with-prettier",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Skyscanner's eslint config with prettier support ",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   "main": "index.js",
   "bin": "main.js",
   "engines": {
-    "node": "^8.9.0",
+    "node": "^12.14.0",
     "npm": "^6.4.1"
   },
   "scripts": {


### PR DESCRIPTION
I can't see any problem running this on the newer LTS, so would like to remove the messages like:
```
npm WARN notsup Unsupported engine for eslint-config-skyscanner-with-prettier@0.8.0
```